### PR TITLE
Fix pull request condition in the community contributions spreadsheet automation

### DIFF
--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   update-spreadsheet:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event.issue.pull_request }}
     steps:
       # Checkout the code for the test-actions repository
     - name: Checkout code


### PR DESCRIPTION
## Summary

I noticed the automated community contributions spreadsheet doesn't get updated after one of the latest action updates. This is due to the action being skipped all the time. I believe it's caused by `if: github.event_name == 'pull_request'`. Updated the condition in accordance with https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only