### PR TITLE
Update community contributions sheet action

### DIFF
--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -1,4 +1,4 @@
-name: Update PR Spreadsheet
+name: Update community pull requests spreadsheet
 on:
   pull_request_target:
     types: [assigned,unassigned,opened,closed,reopened]

--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -1,5 +1,7 @@
 name: Update PR Spreadsheet
 on:
+  pull_request_target:
+    types: [assigned,unassigned,opened,closed,reopened]
   workflow_call:
     secrets:
       CONTRIBUTIONS_SPREADSHEET_ID:

--- a/scripts/update-pr-spreadsheet.js
+++ b/scripts/update-pr-spreadsheet.js
@@ -9,7 +9,7 @@ const extractPRData = (payload) => {
     user_login: pr.user.login,
     title: pr.title,
     repo_name: pr.base.repo.name,
-    updated_at: pr.updated_at,
+    created_at: pr.created_at,
     requested_reviewers: pr.requested_reviewers.map(r => r.login).join(','),
     assignees: pr.assignees.map(a => a.login).join(','),
     user_site_admin: pr.user.site_admin,
@@ -63,8 +63,8 @@ async function updateSpreadsheet(pullRequest) {
     pullRequest.user_login || "",
     pullRequest.title || "",
     pullRequest.repo_name || "",
-    pullRequest.updated_at
-      ? pullRequest.updated_at.split("T")[0].replace("'", "")
+    pullRequest.created_at
+      ? pullRequest.created_at.split("T")[0].replace("'", "")
       : "",
     pullRequest.requested_reviewers || "",
     pullRequest.assignees || "",


### PR DESCRIPTION
## Summary

Updates the action that updates the community contributions spreadsheet:

- (1) Removes information about when a PR was updated in favor of its creation date (that's what I need most, I don't use updated date) [API reference](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request)
- (2) Attempts to make the action run not only when called from other repositories, but also from this .github repository (since we receive community contributions here regularly as well) 

## Reviewer guidance

I'd particularly appreciate feedback on (2) https://github.com/learningequality/.github/commit/fc03eb0ae7071e4cb615c6103ee2763d0a4bb25c - I hope it's that simple but am rather uncertain.