### PR TITLE
Updated github workflow to ignore bot comments

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -14,7 +14,9 @@ jobs:
       ${{
         !github.event.issue.pull_request &&
         github.event.comment.author_association != 'MEMBER' &&
-        github.event.comment.author_association != 'OWNER'
+        github.event.comment.author_association != 'OWNER' &&
+        github.event.comment.user.login != 'sentry-io[bot]' &&
+        github.event.comment.user.login != 'learning-equality-bot[bot]'
       }}
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This PR addresses [issue #12568](https://github.com/learningequality/kolibri/issues/12568) by updating the notify_team_new_comment.yml GitHub Actions workflow. The enhancement ensures that Slack notifications are sent only for comments made by external contributors, effectively excluding specific bot users and repository members.

### Changelog

**Conditional Logic Update:**

Modified the if condition in the contributor_issue_comment job to exclude comments from:
Specific bots ("sentry-io[bot]", "learning-equality-bot[bot]")

### Testing Done

Validated the conditional logic to ensure only external contributor comments trigger Slack notifications.
