### PR TITLE
Add shared action to manages issue headers

### DIFF
--- a/.github/workflows/manage-issue-header.yml
+++ b/.github/workflows/manage-issue-header.yml
@@ -2,13 +2,7 @@ name: Manage issue header
 
 on:
     workflow_call:
-      secrets:
-        LE_BOT_APP_ID:
-            description: "GitHub App ID for authentication"
-            required: true
-        LE_BOT_PRIVATE_KEY:
-            description: "GitHub App Private Key for authentication"
-            required: true
+
 jobs:
   manage-issue-header:
     runs-on: ubuntu-latest
@@ -16,19 +10,12 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == 'help wanted') ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'help wanted')
     steps:
-      - name: Generate App Token
-        id: generate-token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.LE_BOT_APP_ID }}
-          private_key: ${{ secrets.LE_BOT_PRIVATE_KEY }}
-
       - name: Checkout called repository
         uses: actions/checkout@v3
         with:
-          repository: learningequality/.github
-          ref: main
-          token: ${{ steps.generate-token.outputs.token }}
+          repository: MisRob/.github
+          ref: manage-issue-header
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -42,7 +29,7 @@ jobs:
         id: run-script
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const script = require('./scripts/manage-issue-header.js');
             return await script({github, context, core});

--- a/.github/workflows/manage-issue-header.yml
+++ b/.github/workflows/manage-issue-header.yml
@@ -1,0 +1,48 @@
+name: Manage issue header
+
+on:
+    workflow_call:
+      secrets:
+        LE_BOT_APP_ID:
+            description: "GitHub App ID for authentication"
+            required: true
+        LE_BOT_PRIVATE_KEY:
+            description: "GitHub App Private Key for authentication"
+            required: true
+jobs:
+  manage-issue-header:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'help wanted') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'help wanted')
+    steps:
+      - name: Generate App Token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.LE_BOT_APP_ID }}
+          private_key: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+
+      - name: Checkout called repository
+        uses: actions/checkout@v3
+        with:
+          repository: learningequality/.github
+          ref: main
+          token: ${{ steps.generate-token.outputs.token }}
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install 
+      
+      - name: Run script
+        id: run-script
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const script = require('./scripts/manage-issue-header.js');
+            return await script({github, context, core});

--- a/scripts/manage-issue-header.js
+++ b/scripts/manage-issue-header.js
@@ -1,0 +1,82 @@
+/**
+ * Adds/removes issue contributing header when 'help wanted' label is added / removed.
+ */
+
+module.exports = async ({ github, context, core }) => {
+  try {
+    const HELP_WANTED_LABEL = "help wanted";
+
+    const repoOwner = context.repo.owner;
+    const repoName = context.repo.repo;
+    const issueNumber = context.payload.issue.number;
+    const actionType = context.payload.action;
+    const labelName = context.payload.label.name;
+
+    if (labelName !== HELP_WANTED_LABEL) {
+      console.log(`This event does not involve the '${HELP_WANTED_LABEL}' label. Exiting.`);
+      return;
+    }
+
+    const isAddingHeader = actionType === "labeled";
+    const isRemovingHeader = actionType === "unlabeled";
+
+    if (!isAddingHeader && !isRemovingHeader) {
+      console.log(`Unsupported action type: ${actionType}. Exiting.`);
+      return;
+    }
+
+    const issue = await github.rest.issues.get({
+      owner: repoOwner,
+      repo: repoName,
+      issue_number: issueNumber
+    });
+    
+    const currentBody = issue.data.body || "";
+    console.log('Current body:', currentBody)
+
+    const helpWantedHeader = "## Help wanted\n\n";
+    
+    if (isAddingHeader) {
+      await updateIssueWithHeader(github, repoOwner, repoName, issueNumber, currentBody, helpWantedHeader);
+    } else if (isRemovingHeader) {
+      await removeHeaderFromIssue(github, repoOwner, repoName, issueNumber, currentBody, helpWantedHeader);
+    }
+    
+  } catch (error) {
+    core.setFailed(`Error in managing help wanted header: ${error.message}`);
+  }
+};
+
+async function updateIssueWithHeader(github, owner, repo, issueNumber, currentBody, header) {
+  if (currentBody.includes(header)) {
+    console.log("Help wanted header already exists in the issue. No changes needed.");
+    return;
+  }
+  
+  const newBody = header + currentBody;
+    await github.rest.issues.update({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: newBody
+  });
+  
+  console.log(`Successfully added 'Help wanted' header to issue #${issueNumber}`);
+}
+
+async function removeHeaderFromIssue(github, owner, repo, issueNumber, currentBody, header) {
+  if (!currentBody.includes(header)) {
+    console.log("Help wanted header does not exist in the issue. No changes needed.");
+    return;
+  }  
+  const newBody = currentBody.replace(header, "");
+  await github.rest.issues.update({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: newBody
+  });
+  
+  console.log(`Successfully removed 'Help wanted' header from issue #${issueNumber}`);
+}
+

--- a/scripts/manage-issue-header.js
+++ b/scripts/manage-issue-header.js
@@ -34,8 +34,8 @@ module.exports = async ({ github, context, core }) => {
     const currentBody = issue.data.body || "";
     console.log('Current body:', currentBody)
 
-    const helpWantedHeader = "## Help wanted\n\n";
-    
+    const helpWantedHeader = '<!---HEADER START-->\n\n<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">\n\n🙂 Looking for an issue? Welcome! This issue is open for contribution. If this is the first time you’re requesting an issue, please:\n\n- **Read [the contributing guidelines](https://learningequality.org/contributing-to-our-open-code-base/)** carefully. **Pay extra attention to the [Using generative AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai)**. **Pull requests and comments that don’t follow the guidelines won’t be answered.**\n- **Confirm that you’ve read the guidelines** in your comment.\n\n<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">\n\n<!---HEADER END-->'
+
     if (isAddingHeader) {
       await updateIssueWithHeader(github, repoOwner, repoName, issueNumber, currentBody, helpWantedHeader);
     } else if (isRemovingHeader) {


### PR DESCRIPTION
## Summary

In our repositories, we will have the following workflow for managing issue headers based on the presence of 'help wanted' label:

(1) All issue templates will have "This issue is not open for contribution..." by default
(2) After labeling an issue with the 'help wanted', the header will be automatically changed to "This issue is open for contribution".
(3) After removing the 'help wanted' label, the header will be automatically changed back to "This issue is not open for contribution..."

See the [recording](https://www.awesomescreenshot.com/video/39611558?key=75c9e8f3ac2e3db7af45a1c658bfa02a) for the demo of the whole process.

This pull request implements shared action that will address (2) and (3), after we turn it on in all main repositories.

## Reviewer guidance

@marcellamaki The behavior and messages already include all feedback I received some time ago, so I think all should be ready. Would you just please preview the recording and if all looks good, give me final thumbs up? 

@AlexVelezLl Would you please review code? You don't need to test it manually. I tested when I recorded the demo. After you review, I will
- revert https://github.com/learningequality/.github/commit/e8b9083887a1f1c7c0d13d96aa8104ab9bfeca46 which will make this functional in LE environment
- squeeze all commits
- confirm in `test-actions` that all still works
- finally open PRs that turn this on in all main repositories
