### PR TITLE
Add default issue templates and make the header automation to run on issues from this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.md
+++ b/.github/ISSUE_TEMPLATE/bug_issue.md
@@ -4,6 +4,17 @@ about: Report a bug to help us improve
 title: "[Brief description]"
 ---
 
+<!-- DO NOT REMOVE THE HEADER -->
+<!---HEADER START-->
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+❌ **This issue is not open for contribution. Visit <a href="https://learningequality.org/contributing-to-our-open-code-base/" target="_blank">Contributing guidelines</a>** to learn about the contributing process and how to find suitable issues.
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+<!---HEADER END-->
+
 <!--
 Instructions:
  * Fill out the sections below, replace …'s with information about your issue
@@ -57,7 +68,7 @@ Precise steps that someone else can follow in order to see this behavior
 ## Context
 <!--
 Tell us about your environment, including:
- * Software version
+ * Application version
  * Operating system
  * Browser
 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Kolibri GitHub Discussions
+    url: https://github.com/learningequality/kolibri/discussions
+    about: Please ask general questions about contributing to Kolibri or report development server issues here.
+  - name: Learning Equality Community Forum
+    url: https://community.learningequality.org/
+    about: Ask and answer questions about Learning Equality's products and tools, share your experiences using Kolibri, and connect with users around the world.

--- a/.github/ISSUE_TEMPLATE/enhancement_issue.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_issue.md
@@ -1,0 +1,41 @@
+---
+name: Enhancement request
+about: Suggest an idea
+title: "[Title]: [Brief description]"
+---
+
+<!--
+
+Note that anything written between these symbols will not appear in the actual, published issue. They serve as instructions for filling out this template.  Please use the 'preview' tab above this textbox to verify formatting before submitting.
+
+Instructions:
+- Start by replacing the content in "[Title]" and give a "[Brief description]" of the issue above
+- Please remove any unused, optional sections below.
+
+-->
+
+<!-- DO NOT REMOVE THE HEADER -->
+<!---HEADER START-->
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+❌ **This issue is not open for contribution. Visit <a href="https://learningequality.org/contributing-to-our-open-code-base/" target="_blank">Contributing guidelines</a>** to learn about the contributing process and how to find suitable issues.
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+<!---HEADER END-->
+
+## Desired behavior
+<!-- Briefly describe the behavior you would like to see -->
+
+
+## Current behavior
+<!-- Briefly describe the current behavior; you may include screenshots, code, and notes -->
+
+
+## Value add
+<!-- (Optional) Explain why this should be added or changed in KDS and where it could be used -->
+
+
+## Possible tradeoffs
+<!-- (Optional) Explain possible issues/costs that could arise - if any - from implementing this enhancement -->

--- a/.github/ISSUE_TEMPLATE/epic_issue.md
+++ b/.github/ISSUE_TEMPLATE/epic_issue.md
@@ -7,6 +7,17 @@ assignees: ''
 
 ---
 
+<!-- DO NOT REMOVE THE HEADER -->
+<!---HEADER START-->
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+❌ **This issue is not open for contribution. Visit <a href="https://learningequality.org/contributing-to-our-open-code-base/" target="_blank">Contributing guidelines</a>** to learn about the contributing process and how to find suitable issues.
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+<!---HEADER END-->
+
 _[General guidance: When drafting a feature project, the goal is to create a reference for project scope and context. Write for our core product team. The issue should not be overly technical, and should be be comprehensible and a useful reference to devs, designers, and QA team, to build a shared source of understanding. Anyone at LE should be able to read this and more or less understand the project. If there is relevant information or context that is for the internal team only, please add that in a notion page and link it, rather than adding directly to these issues.]_
 
 ## Overview 

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -1,0 +1,17 @@
+---
+name: Other issue
+about: For issues that don't fit any other category
+---
+
+<!-- DO NOT REMOVE THE HEADER -->
+<!---HEADER START-->
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+❌ **This issue is not open for contribution. Visit <a href="https://learningequality.org/contributing-to-our-open-code-base/" target="_blank">Contributing guidelines</a>** to learn about the contributing process and how to find suitable issues.
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+<!---HEADER END-->
+
+## Description

--- a/.github/ISSUE_TEMPLATE/product_issue.md
+++ b/.github/ISSUE_TEMPLATE/product_issue.md
@@ -1,20 +1,32 @@
 ---
-name: Product Issue
+name: Product issue
 about: Create a product issue
 assignees: ''
 
 ---
 
+<!-- DO NOT REMOVE THE HEADER -->
+<!---HEADER START-->
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+❌ **This issue is not open for contribution. Visit <a href="https://learningequality.org/contributing-to-our-open-code-base/" target="_blank">Contributing guidelines</a>** to learn about the contributing process and how to find suitable issues.
+
+<img height="20px" src="https://i.imgur.com/c7hUeb5.jpeg">
+
+<!---HEADER END-->
+
+
 _[General guidance: Product issues should describe the feature, but are not actually technically specced for dev work.]_
 
-## Overview 
+## Overview
 
 _[First, the workflow in one sentence]_
 
 #### Description and outcomes
 _[Then, more detail. Provide a short summary and/or list key outcomes that the user should be able to accomplish with this feature.]_
 
- 
+
 
 #### Resources
 - [ ]  _[Link Gherkin Scenarios]_

--- a/.github/workflows/manage-issue-header.yml
+++ b/.github/workflows/manage-issue-header.yml
@@ -1,6 +1,8 @@
 name: Manage issue header
 
 on:
+    issues:
+      types: [labeled, unlabeled]
     workflow_call:
       secrets:
         LE_BOT_APP_ID:


### PR DESCRIPTION
## Summary

- Adds default issue templates 
  - Collected the current main issue templates from our repositories
  - Made minor changes for consistency, for example in template file names
- Adds the default 'not open for contribution' header to all templates


- Makes the issue header automation to run on issues from this repo

## References

A companion of https://github.com/learningequality/kolibri-design-system/pull/1037

## Reviewer guidance

@marcellamaki feel free to suggest changes via review, or if your draft templates have larger amounts of changes, I welcome you to push directly here.

@rtibbles would you take a peek at the small automation tweak?
