### PR TITLE
Do not send holiday message on pull request comments

### DIFF
--- a/.github/workflows/holiday-message.yml
+++ b/.github/workflows/holiday-message.yml
@@ -24,7 +24,7 @@ jobs:
   post-holiday-message:
     name: Post holiday message
     needs: [check-if-contributor]
-    if: ${{ needs.check-if-contributor.outputs.is_contributor == 'true' }}
+    if: ${{ (github.event.pull_request || !github.event.issue.pull_request) && needs.check-if-contributor.outputs.is_contributor == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate App Token


### PR DESCRIPTION
## Summary

Do not send holiday message on pull request comments. It should only post it when pull request is open, or on issue comments.
