### PR TITLE
Don't post bot replies on dependabot PRs

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -2,6 +2,7 @@
 
 const LE_BOT_USERNAME = 'learning-equality-bot[bot]';
 const SENTRY_BOT_USERNAME = 'sentry-io[bot]';
+const DEPENDABOT_USERNAME = 'dependabot[bot]';
 
 // close contributors are treated a bit special in some workflows,
 // for example, we receive a high priority notification about their
@@ -88,6 +89,7 @@ const HOLIDAY_MESSAGE = `Season’s greetings! 👋 \n\n We’d like to thank ev
 module.exports = {
   LE_BOT_USERNAME,
   SENTRY_BOT_USERNAME,
+  DEPENDABOT_USERNAME,
   CLOSE_CONTRIBUTORS,
   KEYWORDS_DETECT_ASSIGNMENT_REQUEST,
   ISSUE_LABEL_HELP_WANTED,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,4 +1,4 @@
-const { LE_BOT_USERNAME, SENTRY_BOT_USERNAME } = require('./constants');
+const { LE_BOT_USERNAME, SENTRY_BOT_USERNAME, DEPENDABOT_USERNAME } = require('./constants');
 // const { CLOSE_CONTRIBUTORS, TEAMS_WITH_CLOSE_CONTRIBUTORS } = require('./constants');
 const { CLOSE_CONTRIBUTORS } = require('./constants');
 
@@ -10,11 +10,11 @@ async function isBot(username, { core }) {
     core.setFailed('Missing username');
     return false;
   }
-  return [LE_BOT_USERNAME, SENTRY_BOT_USERNAME].includes(username);
+  return [LE_BOT_USERNAME, SENTRY_BOT_USERNAME, DEPENDABOT_USERNAME].includes(username);
 }
 
 /**
- * Checks if a user is a contributor (= not a core team member).
+ * Checks if a user is a contributor (= not a core team member or bot).
  */
 async function isContributor(username, authorAssociation, { github, context, core }) {
   if (!username) {


### PR DESCRIPTION
## Summary

I don't have a neat way to test but think this should prevent LE bot posting on dependabot PRs, such as this one https://github.com/learningequality/ricecooker/pull/646