### PR TITLE
Add dependabot configuration for npm, pip, and github-actions

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      github:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
Configure monthly dependency updates with a 7-day cooldown period to avoid upgrading to newly released versions too quickly. Group GitHub Actions updates together.

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 