### PR TITLE
Auto-request review from rtibblesbot on dependabot PRs

### DIFF
--- a/.github/workflows/call-pull-request-target.yml
+++ b/.github/workflows/call-pull-request-target.yml
@@ -1,7 +1,7 @@
 name: Handle pull request events
 on:
   pull_request_target:
-    types: [review_requested, labeled]
+    types: [opened, review_requested, labeled]
 jobs:
   call-workflow:
     name: Call shared workflow

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,0 +1,31 @@
+name: Request review on dependabot PR
+on:
+  workflow_call:
+    inputs:
+      reviewer:
+        description: 'GitHub username to request review from'
+        type: string
+        default: rtibblesbot
+    secrets:
+      LE_BOT_APP_ID:
+        description: 'GitHub App ID for authentication'
+        required: true
+      LE_BOT_PRIVATE_KEY:
+        description: 'GitHub App Private Key for authentication'
+        required: true
+jobs:
+  request-review:
+    name: Request review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.LE_BOT_APP_ID }}
+          private-key: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+      - name: Request review
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer ${{ inputs.reviewer }}

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -23,3 +23,10 @@ jobs:
     secrets:
       LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
       LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+  dependabot-reviewer:
+    name: Request review on dependabot PR
+    if: ${{ github.event.action == 'opened' && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    uses: learningequality/.github/.github/workflows/dependabot-reviewer.yml@main
+    secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Adds a new reusable workflow `dependabot-reviewer.yml` that requests a review (default: `rtibblesbot`) when a PR is opened by `dependabot[bot]`
- Wires it into the `pull-request-target.yml` dispatch with `if: action == 'opened' && user == 'dependabot[bot]'`
- Extends `call-pull-request-target.yml` triggers to include `opened` so the dispatch sees those events

A follow-up rollout will add `call-pull-request-target.yml` to the active repos that don't have it yet (kolibri-installer-android, -debian, -windows, kolibri-app, kolibri-data-portal, morango, website, kolibri-image-pi, kolibri-sentry-plugin, kolibri-oidc-client-plugin, kolibri-oidc-provider-plugin).

## Test plan

- [ ] Merge, then verify next dependabot PR in `kolibri` (or any repo with the caller already deployed) auto-requests review from `rtibblesbot`

## AI usage

I used Claude Code to design the workflow changes — extending the existing pull-request-target reusable pattern with a new dependabot-reviewer handler and rolling out the caller across our repos. I reviewed the diff manually before opening each PR.