### PR TITLE
Add 'v' to example branch which matches our branch name conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.md
+++ b/.github/ISSUE_TEMPLATE/bug_issue.md
@@ -13,7 +13,7 @@ Instructions:
  * Use the 'preview' function above this text box to verify formatting before submitting
 -->
 
-**Target branch:** <!-- e.g. develop, release-0.17.x -->
+**Target branch:** <!-- e.g. develop, release-v0.17.x -->
 
 ## Observed behavior
 <!--

--- a/.github/ISSUE_TEMPLATE/enhancement_issue.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_issue.md
@@ -15,7 +15,7 @@ Instructions:
 
 -->
 
-**Target branch:** <!-- e.g. develop, release-0.17.x -->
+**Target branch:** <!-- e.g. develop, release-v0.17.x -->
 
 ## Current behavior
 <!-- Briefly describe the current behavior; you may include screenshots, code, and notes -->

--- a/.github/ISSUE_TEMPLATE/technical_task_issue.md
+++ b/.github/ISSUE_TEMPLATE/technical_task_issue.md
@@ -20,7 +20,7 @@ Keep it brief - a few sentences.
 -->
 
 **Complexity:** Low | Medium | High
-**Target branch:** <!-- e.g. develop, release-0.17.x -->
+**Target branch:** <!-- e.g. develop, release-v0.17.x -->
 
 ### Context
 


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
I noticed our target branch example was `release-0.17.x` which was missing a `v` in front of the version. Makes one less thing to update if you use it as a template.

