### PR TITLE
fix: stop stripping issue header on unrelated label changes

### DIFF
--- a/scripts/manage-issue-header.js
+++ b/scripts/manage-issue-header.js
@@ -58,23 +58,28 @@ module.exports = async ({ github, context, core }) => {
         header = isIssueHelpWanted(issue) ? HELP_WANTED_HEADER : NON_HELP_WANTED_HEADER;
         break;
       case 'labeled':
-        if (labelName === HELP_WANTED_LABEL) {
-          header = HELP_WANTED_HEADER;
+        // only the 'help wanted' label affects the header; other labels must not touch the body
+        if (labelName !== HELP_WANTED_LABEL) {
+          core.info(`Ignoring '${actionType}' event for unrelated label '${labelName}'.`);
+          return;
         }
+        header = HELP_WANTED_HEADER;
         break;
       case 'unlabeled':
-        if (labelName === HELP_WANTED_LABEL) {
-          header = NON_HELP_WANTED_HEADER;
-          await deleteBotComments(
-            issueNumber,
-            LE_BOT_USERNAME,
-            ASSIGN_GUIDANCE_MARKER,
-            repoOwner,
-            repoName,
-            github,
-            core,
-          );
+        if (labelName !== HELP_WANTED_LABEL) {
+          core.info(`Ignoring '${actionType}' event for unrelated label '${labelName}'.`);
+          return;
         }
+        header = NON_HELP_WANTED_HEADER;
+        await deleteBotComments(
+          issueNumber,
+          LE_BOT_USERNAME,
+          ASSIGN_GUIDANCE_MARKER,
+          repoOwner,
+          repoName,
+          github,
+          core,
+        );
         break;
       default:
         core.info(`Unsupported action type '${actionType}' or label '${labelName}'. Skipping.`);


### PR DESCRIPTION
## Summary

The header logic was running on every label change - causing the header to be removed when unrelated labels were changed.

## References

Observed on learningequality/studio #5929, #5930, #5814, #5811 (headers stripped after `good first issue` / `DEV: frontend` were added).

Does not restore already-affected issues.

## Reviewer guidance

- Non-`help wanted` `labeled`/`unlabeled` events now `return` before `clearHeader`/`issues.update` — no body write.
- Confirm the `help wanted` removal branch still reaches `deleteBotComments` (moved out of the old `if`).

## AI usage

Claude Code diagnosed the header-stripping bug and wrote the fix.
